### PR TITLE
Display registration keys in university profile page

### DIFF
--- a/cypress/fixtures/successful_subscribed_university_login.json
+++ b/cypress/fixtures/successful_subscribed_university_login.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "id": 1,
+    "name": "Harvard",
+    "email": "harvard@mail.com",
+    "uid": "harvard@mail.com",
+    "role": "university",
+    "subscriber": true
+  }
+}

--- a/cypress/fixtures/successful_subscribed_university_login.json
+++ b/cypress/fixtures/successful_subscribed_university_login.json
@@ -2,8 +2,8 @@
   "data": {
     "id": 1,
     "name": "Harvard",
-    "email": "harvard@mail.com",
-    "uid": "harvard@mail.com",
+    "email": "harvard@harvard.com",
+    "uid": "harvard@harvard.com",
     "role": "university",
     "subscriber": true
   }

--- a/cypress/fixtures/university_registration_keys.json
+++ b/cypress/fixtures/university_registration_keys.json
@@ -1,17 +1,7 @@
 [
-  {
-    "combination": "b3tDSWucTHtzWLNNGFdgagip"
-  },
-  {
-    "combination": "U9YT35JejpfKDy1vfuWTVLyb"
-  },
-  {
-    "combination": "dWCWyfnNn4DVFEHzAAz7b6pw"
-  },
-  {
-    "combination": "6evmpvxxJmHxvWdNZzZYKa4i"
-  },
-  {
-    "combination": "fGygSg6Fxjav78tKEbLzS3TB"
-  }
+  "b3tDSWucTHtzWLNNGFdgagip",
+  "U9YT35JejpfKDy1vfuWTVLyb",
+  "dWCWyfnNn4DVFEHzAAz7b6pw",
+  "6evmpvxxJmHxvWdNZzZYKa4i",
+  "fGygSg6Fxjav78tKEbLzS3TB"
 ]

--- a/cypress/fixtures/university_registration_keys.json
+++ b/cypress/fixtures/university_registration_keys.json
@@ -1,0 +1,9 @@
+{
+  "keys":[
+    "b3tDSWucTHtzWLNNGFdgagip",
+    "U9YT35JejpfKDy1vfuWTVLyb",
+    "dWCWyfnNn4DVFEHzAAz7b6pw",
+    "6evmpvxxJmHxvWdNZzZYKa4i",
+    "fGygSg6Fxjav78tKEbLzS3TB"
+  ]
+}

--- a/cypress/fixtures/university_registration_keys.json
+++ b/cypress/fixtures/university_registration_keys.json
@@ -1,9 +1,17 @@
-{
-  "keys":[
-    "b3tDSWucTHtzWLNNGFdgagip",
-    "U9YT35JejpfKDy1vfuWTVLyb",
-    "dWCWyfnNn4DVFEHzAAz7b6pw",
-    "6evmpvxxJmHxvWdNZzZYKa4i",
-    "fGygSg6Fxjav78tKEbLzS3TB"
-  ]
-}
+[
+  {
+    "combination": "b3tDSWucTHtzWLNNGFdgagip"
+  },
+  {
+    "combination": "U9YT35JejpfKDy1vfuWTVLyb"
+  },
+  {
+    "combination": "dWCWyfnNn4DVFEHzAAz7b6pw"
+  },
+  {
+    "combination": "6evmpvxxJmHxvWdNZzZYKa4i"
+  },
+  {
+    "combination": "fGygSg6Fxjav78tKEbLzS3TB"
+  }
+]

--- a/cypress/integration/universityCanSeeRegistrationKeys.spec.js
+++ b/cypress/integration/universityCanSeeRegistrationKeys.spec.js
@@ -21,7 +21,7 @@ describe("University can see Registration Keys after subscribing", () => {
     cy.get("#subscribe-button").should("not.exist");
     cy.get("#profile-button").click();
     cy.contains("Your Profile");
-    cy.contains("Registration Keys:");
+    cy.get("#registration-keys-title").should("exist");
     cy.contains("b3tDSWucTHtzWLNNGFdgagip");
     cy.contains("U9YT35JejpfKDy1vfuWTVLyb");
     cy.contains("dWCWyfnNn4DVFEHzAAz7b6pw");

--- a/cypress/integration/universityCanSeeRegistrationKeys.spec.js
+++ b/cypress/integration/universityCanSeeRegistrationKeys.spec.js
@@ -13,7 +13,7 @@ describe("University can see Registration Keys after subscribing", () => {
   it("Subscribed University can access profile page and see registration keys", () => {
     cy.route({
       method: "GET",
-      url: "http://localhost:3000/api/v0/users",
+      url: "http://localhost:3000/api/v0/users/1",
       response: "fixture:university_registration_keys.json",
       status: 200
     });
@@ -30,12 +30,6 @@ describe("University can see Registration Keys after subscribing", () => {
   })
 
   it("Unsubscribed University cannot see registration keys on profile", () => {
-    cy.route({
-      method: "GET",
-      url: "http://localhost:3000/api/v0/users",
-      response: "fixture:university_registration_keys.json",
-      status: 200
-    });
     cy.university_login("harvard@mail.com", "password");
     cy.get("#subscribe-button").should("exist");
     cy.get("#profile-button").click();

--- a/cypress/integration/universityCanSeeRegistrationKeys.spec.js
+++ b/cypress/integration/universityCanSeeRegistrationKeys.spec.js
@@ -1,0 +1,20 @@
+describe("University pay for subscription", () => {
+
+  beforeEach(() => {
+    cy.server();
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/v0/articles",
+      response: "fixture:articles.json",
+      status: 200
+    });
+    cy.subscribed_university_login("harvard@mail.com", "password");
+  });
+
+  it("University can access profile page and see registration keys", () => {
+    cy.get("#subscribe-button").should("not.exist");
+    cy.get("#profile-button").click();
+    cy.contains("Your Profile");
+  })
+
+})

--- a/cypress/integration/universityCanSeeRegistrationKeys.spec.js
+++ b/cypress/integration/universityCanSeeRegistrationKeys.spec.js
@@ -17,7 +17,7 @@ describe("University can see Registration Keys after subscribing", () => {
       response: "fixture:university_registration_keys.json",
       status: 200
     });
-    cy.subscribed_university_login("harvard@mail.com", "password");
+    cy.subscribed_university_login("harvard@harvard.com", "password");
     cy.get("#subscribe-button").should("not.exist");
     cy.get("#profile-button").click();
     cy.contains("Your Profile");
@@ -30,7 +30,7 @@ describe("University can see Registration Keys after subscribing", () => {
   })
 
   it("Unsubscribed University cannot see registration keys on profile", () => {
-    cy.university_login("harvard@mail.com", "password");
+    cy.university_login("harvard@harvard.com", "password");
     cy.get("#subscribe-button").should("exist");
     cy.get("#profile-button").click();
     cy.contains("Your Profile");

--- a/cypress/integration/universityCanSeeRegistrationKeys.spec.js
+++ b/cypress/integration/universityCanSeeRegistrationKeys.spec.js
@@ -8,16 +8,16 @@ describe("University can see Registration Keys after subscribing", () => {
       response: "fixture:articles.json",
       status: 200
     });
-    cy.subscribed_university_login("harvard@mail.com", "password");
   });
 
-  it("University can access profile page and see registration keys", () => {
+  it("Subscribed University can access profile page and see registration keys", () => {
     cy.route({
       method: "GET",
-      url: "http://localhost:3000/api/v0/subscriptions",
+      url: "http://localhost:3000/api/v0/users",
       response: "fixture:university_registration_keys.json",
       status: 200
     });
+    cy.subscribed_university_login("harvard@mail.com", "password");
     cy.get("#subscribe-button").should("not.exist");
     cy.get("#profile-button").click();
     cy.contains("Your Profile");
@@ -28,5 +28,19 @@ describe("University can see Registration Keys after subscribing", () => {
     cy.contains("6evmpvxxJmHxvWdNZzZYKa4i");
     cy.contains("fGygSg6Fxjav78tKEbLzS3TB");
   })
+
+  it("Unsubscribed University cannot see registration keys on profile", () => {
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/v0/users",
+      response: "fixture:university_registration_keys.json",
+      status: 200
+    });
+    cy.university_login("harvard@mail.com", "password");
+    cy.get("#subscribe-button").should("exist");
+    cy.get("#profile-button").click();
+    cy.contains("Your Profile");
+    cy.get("#registration-keys-title").should("not.exist");
+  });
 
 })

--- a/cypress/integration/universityCanSeeRegistrationKeys.spec.js
+++ b/cypress/integration/universityCanSeeRegistrationKeys.spec.js
@@ -1,4 +1,4 @@
-describe("University pay for subscription", () => {
+describe("University can see Registration Keys after subscribing", () => {
 
   beforeEach(() => {
     cy.server();

--- a/cypress/integration/universityCanSeeRegistrationKeys.spec.js
+++ b/cypress/integration/universityCanSeeRegistrationKeys.spec.js
@@ -12,9 +12,21 @@ describe("University pay for subscription", () => {
   });
 
   it("University can access profile page and see registration keys", () => {
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/v0/subscriptions",
+      response: "fixture:university_registration_keys.json",
+      status: 200
+    });
     cy.get("#subscribe-button").should("not.exist");
     cy.get("#profile-button").click();
     cy.contains("Your Profile");
+    cy.contains("Registration Keys:");
+    cy.contains("b3tDSWucTHtzWLNNGFdgagip");
+    cy.contains("U9YT35JejpfKDy1vfuWTVLyb");
+    cy.contains("dWCWyfnNn4DVFEHzAAz7b6pw");
+    cy.contains("6evmpvxxJmHxvWdNZzZYKa4i");
+    cy.contains("fGygSg6Fxjav78tKEbLzS3TB");
   })
 
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -59,6 +59,21 @@ Cypress.Commands.add("university_login", (email, password) => {
   cy.get("#login-form-submit").click();
 });
 
+Cypress.Commands.add("subscribed_university_login", (email, password) => {
+  cy.route({
+    method: "POST",
+    url: "http://localhost:3000/api/v0/auth/sign_in",
+    response: "fixture:successful_subscribed_university_login.json"
+  });
+  cy.visit("http://localhost:3001");
+  cy.get("#login-button").click();
+  cy.get("#login-form").within(() => {
+    cy.get("#email").type(email);
+    cy.get("#password").type(password);
+  });
+  cy.get("#login-form-submit").click();
+});
+
 Cypress.Commands.add(
   "university_successful_signup",
   (role, name, email, password, password_confirmation) => {

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import { Switch, Route } from "react-router-dom";
 import SignupForm from "./components/SignupForm";
 import Homepage from "./components/Homepage";
 import PaymentForm from "./components/PaymentForm";
+import UserProfile from "./components/UserProfile";
 
 function App() {
   return (
@@ -18,6 +19,7 @@ function App() {
         <Route exact path="/signup" component={SignupForm} />
         <Route exact path="/createarticle" component={CreateArticleForm} />
         <Route exact path="/payment" component={PaymentForm} />
+        <Route exact path="/profile" component={UserProfile} />
       </Switch>
     </div>
   );

--- a/src/components/CheckoutForm.js
+++ b/src/components/CheckoutForm.js
@@ -36,10 +36,7 @@ class CheckoutForm extends Component {
       });
       if (response.status === 200) {
         this.props.dispatchFlash(response.data.message, "success");
-        this.setState({
-          renderStripeForm: false,
-        });
-        window.location.href = "/profile";
+        this.setState({ renderStripeForm: false });
       }
     } catch (error) {
       this.props.dispatchFlash(error.response.data.errors, "error");

--- a/src/components/CheckoutForm.js
+++ b/src/components/CheckoutForm.js
@@ -37,8 +37,9 @@ class CheckoutForm extends Component {
       if (response.status === 200) {
         this.props.dispatchFlash(response.data.message, "success");
         this.setState({
-          renderStripeForm: false
+          renderStripeForm: false,
         });
+        window.location.href = "/profile";
       }
     } catch (error) {
       this.props.dispatchFlash(error.response.data.errors, "error");

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -15,6 +15,7 @@ class NavBar extends Component {
     let subscribeButton;
     let flashMessage;
     let loginActions;
+    let userProfileButton;
 
     const { activeItem } = this.state
 
@@ -48,8 +49,16 @@ class NavBar extends Component {
           <Menu.Item as={NavLink} to="/signup" id="sign-up-button">Sign Up</Menu.Item>
         </>
       )
-
     }
+
+    if (this.props.currentUser.isSignedIn === true) {
+      userProfileButton = (
+        <>
+          <Menu.Item as={NavLink} to="/profile" id="profile-button">Profile</Menu.Item>
+        </>
+      )
+    }
+
     return (
       <>
         <div className="ui stackable menu">
@@ -87,6 +96,7 @@ class NavBar extends Component {
               {createArticleButton}
               {subscribeButton}
               {loginActions}
+              {userProfileButton}
             </Menu.Menu>
           </Container>
         </div>

--- a/src/components/SignupForm.js
+++ b/src/components/SignupForm.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PaymentForm from "./PaymentForm";
-import { Container, Form, Button, Dropdown } from "semantic-ui-react";
+import { Container, Form, Button } from "semantic-ui-react";
 import { connect } from "react-redux";
 import { registerUser } from "../redux/actions/reduxTokenAuthConfig";
 

--- a/src/components/UserProfile.js
+++ b/src/components/UserProfile.js
@@ -1,11 +1,15 @@
-import React, { Component } from 'react';
+import React, { Component } from "react";
 import { connect } from "react-redux";
 import { Container } from "semantic-ui-react";
-import axios from 'axios'
+import axios from "axios";
 
 class UserProfile extends Component {
   state = {
-    regKeys: ""
+    regKey1: "",
+    regKey2: "",
+    regKey3: "",
+    regKey4: "",
+    regKey5: ""
   };
 
   componentDidMount() {
@@ -17,27 +21,50 @@ class UserProfile extends Component {
       "/subscriptions",
       this.props.currentUser.attributes.uid
     );
-    console.log(response);
-    debugger
     if (response) {
+      let ourArray = response.data;
+      function toArray(ourArray) {
+        const result = [];
+        for (const prop in ourArray) {
+          const value = ourArray[prop];
+          if (typeof value === "object") {
+            result.push(toArray(value));
+          } else {
+            result.push(value);
+          }
+        }
+        return result;
+      }
+      let allKeys = toArray(ourArray);
+
       this.setState({
-        regKeys: response.data.keys[0]
+        regKey1: allKeys[0],
+        regKey2: allKeys[1],
+        regKey3: allKeys[2],
+        regKey4: allKeys[3],
+        regKey5: allKeys[4]
       });
     }
   }
   render() {
     let profileContent;
 
-    if (this.props.currentUser.attributes.role === "university" &&
-    this.props.currentUser.attributes.subscriber === true) {
+    if (
+      this.props.currentUser.attributes.role === "university" &&
+      this.props.currentUser.attributes.subscriber === true
+    ) {
       profileContent = (
         <div>
           <h1>Registration Keys:</h1>
-          <div>{this.state.regKeys}</div>
+          <div>{this.state.regKey1}</div>
+          <div>{this.state.regKey2}</div>
+          <div>{this.state.regKey3}</div>
+          <div>{this.state.regKey4}</div>
+          <div>{this.state.regKey5}</div>
         </div>
       );
     }
-       
+
     return (
       <Container>
         <h1>Your Profile</h1>
@@ -47,13 +74,10 @@ class UserProfile extends Component {
   }
 }
 
-
 const mapStateToProps = state => {
   return {
     currentUser: state.reduxTokenAuth.currentUser
   };
 };
 
-export default connect(
-  mapStateToProps
-)(UserProfile);
+export default connect(mapStateToProps)(UserProfile);

--- a/src/components/UserProfile.js
+++ b/src/components/UserProfile.js
@@ -5,11 +5,7 @@ import axios from "axios";
 
 class UserProfile extends Component {
   state = {
-    regKey1: "",
-    regKey2: "",
-    regKey3: "",
-    regKey4: "",
-    regKey5: ""
+    registrationKeys: [],
   };
 
   componentDidMount() {
@@ -18,36 +14,19 @@ class UserProfile extends Component {
 
   async getUniKeys() {
     const response = await axios.get(
-      "/subscriptions",
-      this.props.currentUser.attributes.uid
+      `/users/${this.props.currentUser.attributes.id}`
     );
     if (response) {
-      let ourArray = response.data;
-      function toArray(ourArray) {
-        const result = [];
-        for (const prop in ourArray) {
-          const value = ourArray[prop];
-          if (typeof value === "object") {
-            result.push(toArray(value));
-          } else {
-            result.push(value);
-          }
-        }
-        return result;
-      }
-      let allKeys = toArray(ourArray);
-
-      this.setState({
-        regKey1: allKeys[0],
-        regKey2: allKeys[1],
-        regKey3: allKeys[2],
-        regKey4: allKeys[3],
-        regKey5: allKeys[4]
-      });
+      this.setState({ registrationKeys: response.data })
     }
   }
   render() {
     let profileContent;
+    let registrationKeysDisplay = this.state.registrationKeys.map(registrationKey => {
+      return (
+        <div key={registrationKey}>{registrationKey}</div>
+      )
+    })
 
     if (
       this.props.currentUser.attributes.role === "university" &&
@@ -55,12 +34,8 @@ class UserProfile extends Component {
     ) {
       profileContent = (
         <div>
-          <h1>Registration Keys:</h1>
-          <div>{this.state.regKey1}</div>
-          <div>{this.state.regKey2}</div>
-          <div>{this.state.regKey3}</div>
-          <div>{this.state.regKey4}</div>
-          <div>{this.state.regKey5}</div>
+          <h1 id="registration-keys-title">Registration Keys:</h1>
+          {registrationKeysDisplay}
         </div>
       );
     }

--- a/src/components/UserProfile.js
+++ b/src/components/UserProfile.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from "react-redux";
+import { Container } from "semantic-ui-react";
 
 class UserProfile extends Component {
   state = {
@@ -10,8 +11,10 @@ class UserProfile extends Component {
 
   render () {
     return (
-      <h1>Your Profile</h1>
-    )
+      <Container>
+        <h1>Your Profile</h1>
+      </Container>
+    );
   }
 }
 

--- a/src/components/UserProfile.js
+++ b/src/components/UserProfile.js
@@ -1,18 +1,47 @@
 import React, { Component } from 'react';
 import { connect } from "react-redux";
 import { Container } from "semantic-ui-react";
+import axios from 'axios'
 
 class UserProfile extends Component {
   state = {
-    name: '',
-    email: '',
-    role: '',
+    regKeys: ""
+  };
+
+  componentDidMount() {
+    this.getUniKeys();
   }
 
-  render () {
+  async getUniKeys() {
+    const response = await axios.get(
+      "/subscriptions",
+      this.props.currentUser.attributes.uid
+    );
+    console.log(response);
+    debugger
+    if (response) {
+      this.setState({
+        regKeys: response.data.keys[0]
+      });
+    }
+  }
+  render() {
+    let profileContent;
+
+    if (this.props.currentUser.attributes.role === "university" &&
+    this.props.currentUser.attributes.subscriber === true) {
+      profileContent = (
+        <div>
+          <h1>Registration Keys:</h1>
+          <div>{this.state.regKeys}</div>
+        </div>
+      );
+    }
+       
     return (
       <Container>
         <h1>Your Profile</h1>
+        {profileContent}
       </Container>
     );
   }

--- a/src/components/UserProfile.js
+++ b/src/components/UserProfile.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { createSecureContext } from 'tls';
+import { connect } from "react-redux";
 
 class UserProfile extends Component {
   state = {
@@ -10,7 +10,7 @@ class UserProfile extends Component {
 
   render () {
     return (
-      <h1>User Profile Page</h1>
+      <h1>Your Profile</h1>
     )
   }
 }
@@ -23,6 +23,5 @@ const mapStateToProps = state => {
 };
 
 export default connect(
-  mapStateToProps,
-  { currentUser }
+  mapStateToProps
 )(UserProfile);

--- a/src/redux/actions/reduxTokenAuthConfig.js
+++ b/src/redux/actions/reduxTokenAuthConfig.js
@@ -7,6 +7,7 @@ let authUrl = baseUrl + "/auth";
 const config = {
   authUrl: authUrl,
   userAttributes: {
+    id: "id",
     uid: "uid",
     role: "role",
     subscriber: "subscriber"


### PR DESCRIPTION
### User Story

```
As university user,
In order to enable my research groups to sign up,
I want to see the registration keys associated with my paid subscription on my profile page.
```
### Feature description
https://www.pivotaltracker.com/story/show/168108135

### Description of PR
PR introduces a University User redirect from the payment form to the user profile page (if payment is succeeded), and here the Research Group Keys will be displayed. We are making a GET request to the API to fetch that particular user's keys. The response handling is perfectly aligned with what is being sent to us from the backend.

### Screenshots
<img width="970" alt="Screen Shot 2019-08-28 at 00 34 48" src="https://user-images.githubusercontent.com/50362596/63812782-bf31cf00-c92b-11e9-81c3-40a333c3522d.png">


### What did we learn?
The importance of having the front and backend aligned so that the requests are well made, and the responses handled properly.
